### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/breadcrumbs/index.ts
+++ b/src/breadcrumbs/index.ts
@@ -15,8 +15,7 @@ class Breadcrumbs {
   };
 
   constructor() {
-    const state = this.flux.store.getState();
-    this.state = { fields: [], originalQuery: Selectors.query(state) };
+    this.state = { fields: [], originalQuery: this.select(Selectors.query) };
   }
 
   init() {
@@ -37,7 +36,7 @@ class Breadcrumbs {
     this.set({ correctedQuery })
 
   updateFields = () => {
-    const navigations = Selectors.navigations(this.flux.store.getState());
+    const navigations = this.select(Selectors.navigations);
     this.set({
       fields: navigations.filter((navigation) => navigation.selected.length !== 0)
         .map((navigation) => navigation.field)

--- a/src/refinement-crumbs/index.ts
+++ b/src/refinement-crumbs/index.ts
@@ -30,7 +30,7 @@ class RefinementCrumbs {
 
   selectRefinements() {
     const field = this.field;
-    const navigation = Selectors.navigation(this.flux.store.getState(), field);
+    const navigation = this.select(Selectors.navigation, field);
     if (navigation) {
       const { range, refinements, selected } = navigation;
 

--- a/test/unit/breadcrumbs.ts
+++ b/test/unit/breadcrumbs.ts
@@ -7,9 +7,10 @@ const QUERY = 'ballroom shoes';
 
 suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias }) => {
   let breadcrumbs: Breadcrumbs;
+  let select: sinon.SinonSpy;
 
   beforeEach(() => {
-    Breadcrumbs.prototype.select = <any>spy(() => QUERY);
+    select = Breadcrumbs.prototype.select = <any>spy(() => QUERY);
     Breadcrumbs.prototype.flux = <any>{};
     breadcrumbs = new Breadcrumbs();
   });
@@ -34,7 +35,7 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
 
     describe('state', () => {
       it('should set initial value', () => {
-        expect(Breadcrumbs.prototype.select).to.be.calledWith(Selectors.query);
+        expect(select).to.be.calledWith(Selectors.query);
         expect(breadcrumbs.state).to.eql({
           fields: [],
           originalQuery: QUERY
@@ -110,14 +111,14 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
     it('should set fields', () => {
       const state = { a: 'b' };
       const navigations = [{ selected: [1], field: 'c' }, { selected: [2, 3], field: 'd' }, { selected: [] }];
-      const select = breadcrumbs.select = <any>spy(() => navigations);
+      const localSelect = breadcrumbs.select = <any>spy(() => navigations);
       const set = breadcrumbs.set = spy();
       breadcrumbs.flux = <any>{ store: { getState: () => state } };
 
       breadcrumbs.updateFields();
 
       expect(set).to.be.calledWith({ fields: ['c', 'd'] });
-      expect(select).to.be.calledWith(Selectors.navigations);
+      expect(localSelect).to.be.calledWith(Selectors.navigations);
     });
   });
 });

--- a/test/unit/breadcrumbs.ts
+++ b/test/unit/breadcrumbs.ts
@@ -7,10 +7,10 @@ const QUERY = 'ballroom shoes';
 
 suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias }) => {
   let breadcrumbs: Breadcrumbs;
-  let select: sinon.SinonSpy;
+  let select: sinon.SinonStub;
 
   beforeEach(() => {
-    select = Breadcrumbs.prototype.select = <any>spy(() => QUERY);
+    select = Breadcrumbs.prototype.select = stub().returns(QUERY);
     Breadcrumbs.prototype.flux = <any>{};
     breadcrumbs = new Breadcrumbs();
   });
@@ -114,7 +114,7 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
     it('should set fields', () => {
       const state = { a: 'b' };
       const navigations = [{ selected: [1], field: 'c' }, { selected: [2, 3], field: 'd' }, { selected: [] }];
-      select = breadcrumbs.select = <any>spy(() => navigations);
+      select.returns(navigations);
       const set = breadcrumbs.set = spy();
       breadcrumbs.flux = <any>{ store: { getState: () => state } };
 

--- a/test/unit/breadcrumbs.ts
+++ b/test/unit/breadcrumbs.ts
@@ -14,7 +14,10 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
     Breadcrumbs.prototype.flux = <any>{};
     breadcrumbs = new Breadcrumbs();
   });
-  afterEach(() => delete Breadcrumbs.prototype.flux);
+  afterEach(() => {
+    delete Breadcrumbs.prototype.flux;
+    delete Breadcrumbs.prototype.select;
+  });
 
   itShouldBeConfigurable(Breadcrumbs);
   itShouldHaveAlias(Breadcrumbs, 'breadcrumbs');
@@ -111,14 +114,14 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
     it('should set fields', () => {
       const state = { a: 'b' };
       const navigations = [{ selected: [1], field: 'c' }, { selected: [2, 3], field: 'd' }, { selected: [] }];
-      const localSelect = breadcrumbs.select = <any>spy(() => navigations);
+      select = breadcrumbs.select = <any>spy(() => navigations);
       const set = breadcrumbs.set = spy();
       breadcrumbs.flux = <any>{ store: { getState: () => state } };
 
       breadcrumbs.updateFields();
 
       expect(set).to.be.calledWith({ fields: ['c', 'd'] });
-      expect(localSelect).to.be.calledWith(Selectors.navigations);
+      expect(select).to.be.calledWith(Selectors.navigations);
     });
   });
 });

--- a/test/unit/breadcrumbs.ts
+++ b/test/unit/breadcrumbs.ts
@@ -4,14 +4,13 @@ import Breadcrumbs from '../../src/breadcrumbs';
 import suite from './_suite';
 
 const QUERY = 'ballroom shoes';
-const STATE = { a: 'b' };
 
 suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias }) => {
   let breadcrumbs: Breadcrumbs;
 
   beforeEach(() => {
     Breadcrumbs.prototype.select = <any>spy(() => QUERY);
-    Breadcrumbs.prototype.flux = <any>{ store: { getState: () => STATE } };
+    Breadcrumbs.prototype.flux = <any>{};
     breadcrumbs = new Breadcrumbs();
   });
   afterEach(() => delete Breadcrumbs.prototype.flux);

--- a/test/unit/breadcrumbs.ts
+++ b/test/unit/breadcrumbs.ts
@@ -7,11 +7,10 @@ const QUERY = 'ballroom shoes';
 const STATE = { a: 'b' };
 
 suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias }) => {
-  let querySelector: sinon.SinonStub;
   let breadcrumbs: Breadcrumbs;
 
   beforeEach(() => {
-    querySelector = stub(Selectors, 'query').returns(QUERY);
+    Breadcrumbs.prototype.select = <any>spy(() => QUERY);
     Breadcrumbs.prototype.flux = <any>{ store: { getState: () => STATE } };
     breadcrumbs = new Breadcrumbs();
   });
@@ -36,7 +35,7 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
 
     describe('state', () => {
       it('should set initial value', () => {
-        expect(querySelector).to.be.calledWith(STATE);
+        expect(Breadcrumbs.prototype.select).to.be.calledWith(Selectors.query);
         expect(breadcrumbs.state).to.eql({
           fields: [],
           originalQuery: QUERY
@@ -112,14 +111,14 @@ suite('Breadcrumbs', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveA
     it('should set fields', () => {
       const state = { a: 'b' };
       const navigations = [{ selected: [1], field: 'c' }, { selected: [2, 3], field: 'd' }, { selected: [] }];
-      const selectNavigations = stub(Selectors, 'navigations').returns(navigations);
+      const select = breadcrumbs.select = <any>spy(() => navigations);
       const set = breadcrumbs.set = spy();
       breadcrumbs.flux = <any>{ store: { getState: () => state } };
 
       breadcrumbs.updateFields();
 
       expect(set).to.be.calledWith({ fields: ['c', 'd'] });
-      expect(selectNavigations).to.be.calledWith(state);
+      expect(select).to.be.calledWith(Selectors.navigations);
     });
   });
 });

--- a/test/unit/refinement-crumbs.ts
+++ b/test/unit/refinement-crumbs.ts
@@ -156,7 +156,7 @@ suite('RefinementCrumbs', ({ expect, spy, stub }) => {
 
     it('should return undefined if navigation is undefined', () => {
       const field = refinementCrumbs.field = 'hat';
-      const select = refinementCrumbs.select = spy(() => undefined);
+      const select = refinementCrumbs.select = spy();
       const state = { a: 'b' };
       refinementCrumbs.flux = <any>{ store: { getState: () => state } };
 

--- a/test/unit/refinement-crumbs.ts
+++ b/test/unit/refinement-crumbs.ts
@@ -162,7 +162,7 @@ suite('RefinementCrumbs', ({ expect, spy, stub }) => {
 
       const refinements = refinementCrumbs.selectRefinements();
 
-      expect(refinements).to.eql(undefined);
+      expect(refinements).to.be.undefined;
       expect(select).to.be.calledWith(Selectors.navigation, field);
     });
   });

--- a/test/unit/refinement-crumbs.ts
+++ b/test/unit/refinement-crumbs.ts
@@ -136,7 +136,7 @@ suite('RefinementCrumbs', ({ expect, spy, stub }) => {
         refinements: [{ a: 'b' }, { c: 'd' }, { e: 'f' }],
       };
       const field = refinementCrumbs.field = 'colour';
-      const selectNavigation = stub(Selectors, 'navigation').returns(navigation);
+      const select = refinementCrumbs.select = spy(() => navigation);
       refinementCrumbs.flux = <any>{ store: { getState: () => state } };
 
       const refinements = refinementCrumbs.selectRefinements();
@@ -151,7 +151,7 @@ suite('RefinementCrumbs', ({ expect, spy, stub }) => {
           { field, range, index: 2, selected: true, e: 'f' },
         ]
       });
-      expect(selectNavigation).to.be.calledWith(state, field);
+      expect(select).to.be.calledWith(Selectors.navigation, field);
     });
   });
 });

--- a/test/unit/refinement-crumbs.ts
+++ b/test/unit/refinement-crumbs.ts
@@ -153,5 +153,17 @@ suite('RefinementCrumbs', ({ expect, spy, stub }) => {
       });
       expect(select).to.be.calledWith(Selectors.navigation, field);
     });
+
+    it('should return undefined if navigation is undefined', () => {
+      const field = refinementCrumbs.field = 'hat';
+      const select = refinementCrumbs.select = spy(() => undefined);
+      const state = { a: 'b' };
+      refinementCrumbs.flux = <any>{ store: { getState: () => state } };
+
+      const refinements = refinementCrumbs.selectRefinements();
+
+      expect(refinements).to.eql(undefined);
+      expect(select).to.be.calledWith(Selectors.navigation, field);
+    });
   });
 });


### PR DESCRIPTION
Also added a test to get to 100% coverage.
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
